### PR TITLE
NCC: Fix pushing to tags

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -2,6 +2,8 @@ name: ncc
 
 on:
   push:
+    tags-ignore:
+      - '**'
     paths:
       - 'ncc/package-lock.json'
       - 'ncc/src/**'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ updated.
 name: ncc
 on:
   push:
+    tags-ignore:
+      # Can't push a build commit to a tag, so ignore them all
+      - '**'
     paths:
       # Include any files that could require rebuilding
       - 'package-lock.json'

--- a/ncc/dist/index.js
+++ b/ncc/dist/index.js
@@ -4038,12 +4038,7 @@ function run() {
             core.endGroup();
         }
         catch (error) {
-            if (error instanceof Error) {
-                core.setFailed(`ncc failed! ${error.message}`);
-            }
-            else {
-                core.setFailed('ncc failed! Unable to read error.');
-            }
+            core.setFailed(`ncc was not successful: ${error}`);
         }
     });
 }

--- a/ncc/src/main.ts
+++ b/ncc/src/main.ts
@@ -49,11 +49,7 @@ async function run() {
     core.endGroup()
 
   } catch (error) {
-    if (error instanceof Error) {
-      core.setFailed(`ncc failed! ${error.message}`)
-    } else {
-      core.setFailed('ncc failed! Unable to read error.')
-    }
+    core.setFailed(`ncc was not successful: ${error}`)
   }
 }
 


### PR DESCRIPTION
Before this, pushes triggered by tags would fail without displaying the warning message we intended to be displayed. Ultimately, tags cannot be built for as we can't push a build commit onto a tag.

In this PR I simplified our error handling and updated the workflows to ignore all tags.