### PR TITLE
🐺 Add `@planningcenter/balto-maintainers` as `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sheck
+* @planningcenter/balto-maintainers


### PR DESCRIPTION
This team was recently created to address this concern.