### PR TITLE
Add release workflow to be used by balto-utils

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -1,0 +1,16 @@
+name: Release Tagger
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  update-semver-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update Semver Tags
+        uses: tchupp/actions-update-semver-tags@v1


### PR DESCRIPTION
We created the release-tagger reusable workflow in #7 but did not add it to balto-utils itself.

There is a _chance_ we could do this by adding a second trigger to the release-tagger workflow (with the push tags filter), but I worry that it could be confusing to others (or even future me) as the tags filter would have to be ignored for external usage.

Also, I went with manually defining the workflow instead of self referencing because, as I've found with the `ncc` action, it can be very frustrating to debug when you've added all these changes to a branch only to find out it's been running `main` the entire time.

After this is merged, I'll delete the v1 branch.