### PR TITLE
Fix example and internal NCC workflow

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -2,7 +2,7 @@ name: ncc
 
 on:
   push:
-    tags-ignore:
+    branches:
       - '**'
     paths:
       - 'ncc/package-lock.json'

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ updated.
 name: ncc
 on:
   push:
-    tags-ignore:
-      # Can't push a build commit to a tag, so ignore them all
+    # Can't push a build commit to a tag, so only run for branches
+    branches:
       - '**'
     paths:
       # Include any files that could require rebuilding


### PR DESCRIPTION
Only specifying the tags to ignore makes Github actions implicitly ignore all branch pushes, instead of the desired/intended usage: all branches, no tags.

Setting the branch filter to allow everything does this. I'll be going through actions using balto-utils and making PRs to fix this broken behavior that I previously added.