### PR TITLE
Add support for yarn 3+

### DIFF
--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -17,6 +17,14 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
+    - name: Cache yarn cache
+      id: cache-yarn-cache
+      uses: actions/cache@v3
+      with:
+        path: .yarn/cache
+        key: ${{ runner.os }}-${{ inputs.node-version }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.node-version }}-yarn-cache-
     - run: |
         yarn_version=$(yarn --version)
         major_version=$(echo "${yarn_version}" | cut -d. -f1)

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -35,7 +35,6 @@ inputs:
   yarn-version:
     description: Version of yarn to use
     required: false
-    default: "1.22.17"
 branding:
   icon: life-buoy
   color: orange

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -29,7 +29,7 @@ runs:
         yarn_version=$(yarn --version)
         major_version=$(echo "${yarn_version}" | cut -d. -f1)
         if [[ "${major_version}" != "1" ]]; then
-          yarn install --frozen-lockfile --immutable
+          yarn install --immutable
         else
           yarn install --frozen-lockfile --prefer-offline --immutable
         fi

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -16,14 +16,26 @@ runs:
         path: node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-            ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
-    - run: yarn install --frozen-lockfile --prefer-offline --immutable
+          ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
+    - run: corepack enable
+      shell: bash
+    - run: |
+        if [ -n "${{ inputs.yarn-version }}" ]; then
+          yarn set version ${{ inputs.yarn-version }}
+          yarn install --frozen-lockfile --immutable
+        else
+          yarn install --frozen-lockfile --prefer-offline --immutable
+        fi
       shell: bash
 inputs:
   node-version:
     description: Version of node to use
     required: false
-    default: '18'
+    default: "18"
+  yarn-version:
+    description: Version of yarn to use
+    required: false
+    default: "1.22.17"
 branding:
   icon: life-buoy
   color: orange

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -17,8 +17,6 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
-    - run: corepack enable
-      shell: bash
     - run: |
         yarn_version=$(yarn --version)
         major_version=$(echo "${yarn_version}" | cut -d. -f1)
@@ -33,9 +31,6 @@ inputs:
     description: Version of node to use
     required: false
     default: "18"
-  yarn-version:
-    description: Version of yarn to use
-    required: false
 branding:
   icon: life-buoy
   color: orange

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -20,8 +20,9 @@ runs:
     - run: corepack enable
       shell: bash
     - run: |
-        if [ -n "${{ inputs.yarn-version }}" ]; then
-          yarn set version ${{ inputs.yarn-version }}
+        yarn_version=$(yarn --version)
+        major_version=$(echo "${yarn_version}" | cut -d. -f1)
+        if [[ "${major_version}" != "1" ]]; then
           yarn install --frozen-lockfile --immutable
         else
           yarn install --frozen-lockfile --prefer-offline --immutable


### PR DESCRIPTION
- Drop the `--prefer-offline` flag if the yarn magor version is not 1 since it is not supported in v3+ of yarn.
- Add caching to `.yarn/cache` which yarn 3+ uses as it's cache.

I tested this on https://github.com/planningcenter/church-center/pull/2256 and it works well.