### PR TITLE
Simplify yarn & npm cache

### DIFF
--- a/npm/action.yml
+++ b/npm/action.yml
@@ -9,23 +9,15 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-            ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
+        cache: npm
+        cache-dependency-path: "**/package-lock.json"
     - run: npm ci
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
 inputs:
   node-version:
     description: Version of node to use
     required: false
-    default: '18'
+    default: "18"
 branding:
   icon: life-buoy
   color: orange

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -9,22 +9,8 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ inputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.node-version }}-node-modules-
-    - name: Cache yarn cache
-      id: cache-yarn-cache
-      uses: actions/cache@v3
-      with:
-        path: .yarn/cache
-        key: ${{ runner.os }}-${{ inputs.node-version }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.node-version }}-yarn-cache-
+        cache: yarn
+        cache-dependency-path: "**/yarn.lock"
     - run: |
         yarn_version=$(yarn --version)
         major_version=$(echo "${yarn_version}" | cut -d. -f1)


### PR DESCRIPTION
## The Problem

Currently, we cache the entirety of node_modules. The setup-node action has caching built in, but it explicitly _does not_ cache node_modules and instead caches the global caches of npm/yarn/etc. The stated reasoning from their docs is that it allows you to maintain compatibility between different node versions.

After adding support for ESLint v9 in balto-eslint, we saw an issue where linting was failing due to a module resolution issue. After using a branch with these changes, those issues went away.

## The Change

In this PR, I'm proposing we switch away from our own managed version of caching node_modules to leaning into the built-in caching from setup-node. Performance wise, it's _about_ the same when looking at the entire run. The initial install is slower, but saving the cache in the post-run step is faster.

Overall, it feels like a win to reduce complexity and let setup-node manage the caching. As a bonus, there are currently warnings about using an outdated version of actions/cache which will be going away with this change.

If we merge this, my current plans are to release this as a minor version bump.